### PR TITLE
.gitignore additions for macOS environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ desktop.ini
 
 # VS Code
 .vscode
+
+#macOS-specific changes
+.DS_Store
+*/DS_Store


### PR DESCRIPTION
Running 'git status' would pull up files generated by macOS, added them to gitignore