### PR TITLE
Updated setup.py to use xlrd version 1.2.0 or less

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools_info = {
 		'dnspython>=1.16.0',
 		'networkx>=2.3',
 		'pygal>=2.4.0',
-		'xlrd>=1.2.0',
+		'xlrd<=1.2.0',
 		'more_itertools>=7.2.0',
 	    'PyYAML>=5.1.2'],
 	'classifiers': [


### PR DESCRIPTION
In versions after 1.2.0, xlrd removes support for xlsx files. To use pandas.read_excel, pandas developers recommend using xlrd version 1.2.0. Addresses issue #183 