### PR TITLE
Bugfixes related to OpenMKM input file (thermo.yaml) creation. 

### DIFF
--- a/pmutt/io/omkm.py
+++ b/pmutt/io/omkm.py
@@ -174,6 +174,7 @@ def write_thermo_yaml(phases=None, species=None, reactions=None,
                       lateral_interactions=None, units=None,
                       filename=None, T=300., P=1., newline='\n',
                       ads_act_method='get_H_act',
+                      use_motz_wise='False',
                       yaml_options={'default_flow_style': None, 'indent': 2,
                                     'sort_keys': False, 'width': 79}):
     """Writes the units, phases, species, lateral interactions, reactions and 
@@ -246,6 +247,7 @@ def write_thermo_yaml(phases=None, species=None, reactions=None,
             if reaction.id is None:
                 reaction.id = 'r_{:04d}'.format(i)
                 i += 1
+            reaction.use_motz_wise = use_motz_wise
             # Write reaction
             reaction_dict = reaction.to_omkm_yaml(units=units, T=T)
             reactions_out.append(reaction_dict)

--- a/pmutt/mixture/cov.py
+++ b/pmutt/mixture/cov.py
@@ -204,13 +204,15 @@ class PiecewiseCovEffect(_ModelBase):
                                    self.intervals, slopes, self.name))
         return lat_inter_str
 
-    def to_omkm_yaml(self, energy_unit=None, units=None):
+    def to_omkm_yaml(self, energy_unit='kcal', quantity_unit='mol', units=None):
         """Writes the object in Cantera's YAML format.
 
         Parameters
         ----------
             energy_unit : str, optional
-                Unit to use for energy. Default is 'cal/mol'
+                Energy unit for slopes. Default is 'kcal'
+            quantity_unit : str, optional
+                Quantity unit for slopes. Default is 'mol'
             units : :class:`~pmutt.omkm.units.Units` object
                 If specified, `energy_unit` is overwritten. Default is None.
         Returns
@@ -218,11 +220,15 @@ class PiecewiseCovEffect(_ModelBase):
             yaml_dict : dict
                 Dictionary compatible with Cantera's YAML format
         """
+        if units is not None:
+            energy_unit = units.energy
+            quantity_unit = units.quantity
+        final = '{}/{}'.format(energy_unit, quantity_unit)
         yaml_dict = {}
         yaml_dict['species'] = [self.name_i, self.name_j]
         yaml_dict['coverage-threshold'] = self.intervals
         '''Assign slope'''
-        strength_param = _Param('strength', self.slopes, '_energy')
+        strength_param = _Param('strength', self.slopes, final)
         _assign_yaml_val(strength_param, yaml_dict, units)
         yaml_dict['id'] = self.name
         return yaml_dict

--- a/pmutt/omkm/phase.py
+++ b/pmutt/omkm/phase.py
@@ -98,7 +98,7 @@ class StoichSolid(phase_cantera.StoichSolid):
             'name': self.name,
             'elements': list(self.elements),
             'species': species_names,
-            'thermo': 'fixed-stoichiometry'
+            'thermo': 'ref-state-fixed-stoichiometry'
         }
         return yaml_dict
 
@@ -330,7 +330,7 @@ class InteractingInterface(phase_cantera.Phase):
 
         '''Assign thermo depending on presence of lateral interactions'''
         if self.interactions is None or len(self.interactions) == 0:
-            yaml_dict['thermo'] = 'ideal-surface'
+            yaml_dict['thermo'] = 'surface-lateral-interaction'
             yaml_dict['interactions'] = 'none'
         else:
             yaml_dict['thermo'] = 'surface-lateral-interaction'


### PR DESCRIPTION
In this pull request 4 files are changed to ensure pMuTT is writing correct OpenMKM YAML files. If any of these fixes need to be done in other places or you have question, happy to discuss about it! 

Thid pull request will close #199 that I opened recently. 

1. pmutt/io/omkm.py - Updating this file to fix a bug, where the flag activating Motz-Wise corrections for the sticking coeffient is not written in the thermo.yaml file. 
2. pmutt/mixture/cov.py - Updating this file, to ensure that correct units are written for the lateral interaction strength/slope when writing the thermo.yaml file. 
3. pmutt/omkm/phase.py - Updating the thermo model keywords when writing the thermo.yaml file. Fixes on line 100/101 is related to an OpenMKM issue [vlachosgroup/openMKM#42](https://github.com/VlachosGroup/openmkm/issues/42#issuecomment-946924554). 
4. pmutt/omkm/reaction.py - Updating this file to fiz a bug, where explicit Ea values provided in the Excel file aren't used when making OpenMKM yaml.thermo file. 