### PR TITLE
Fix deprecated numpy function

### DIFF
--- a/pmutt/empirical/nasa.py
+++ b/pmutt/empirical/nasa.py
@@ -2216,7 +2216,7 @@ def get_nasa9_HoRT(a, T):
 
     .. _`numpy.ndarray`: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
     """
-    T = float(T)
+    T = float(np.squeeze(T))
     T_arr = np.array([
         -(T**-2),
         np.log(T) / T, np.ones_like(T), T / 2., (T**2) / 3., (T**3) / 4.,
@@ -2241,7 +2241,7 @@ def get_nasa9_SoR(a, T):
 
     .. _`numpy.ndarray`: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
     """
-    T = float(T)
+    T = float(np.squeeze(T))
     T_arr = np.array([
         -(T**-2) / 2., -(T**-1),
         np.log(T), T, (T**2) / 2., (T**3) / 3., (T**4) / 4., np.zeros_like(T),

--- a/pmutt/empirical/shomate.py
+++ b/pmutt/empirical/shomate.py
@@ -772,6 +772,7 @@ def _fit_HoRT(T_ref, HoRT_ref, a, units):
 
     .. _`numpy.ndarray`: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
     """
+    T_ref = np.squeeze(T_ref)
     a[5] = (HoRT_ref
             - get_shomate_HoRT(T=np.array([T_ref]), a=a, units=units)) \
         * c.R(units)*T_ref/c.prefixes['k']


### PR DESCRIPTION
Conversion of an array with ndim > 0 to a scalar is deprecated. Impacts nasa.py and shomate.py